### PR TITLE
docs: implement Google-style docstrings in base classes (#3)

### DIFF
--- a/src/instrumation/device.py
+++ b/src/instrumation/device.py
@@ -2,19 +2,35 @@ import time
 from .transport import VisaDriver, SerialDriver
 
 class UUTHandler:
-    """
-    The main object the user interacts with.
+    """The main object the user interacts with.
+
     It manages the connection to the specific UUT.
+
+    Attributes:
+        box (SerialDriver): Driver for the serial connection to the multiplexer/box.
+        inst (VisaDriver): Driver for the VISA instrument connection.
     """
     def __init__(self, serial_port, visa_address):
-        # We assume the user needs BOTH to test a UUT properly
+        """Initializes the UUTHandler.
+
+        We assume the user needs BOTH to test a UUT properly.
+
+        Args:
+            serial_port (str): The serial port for the box (e.g., 'COM3').
+            visa_address (str): The VISA address for the instrument (e.g., 'GPIB0::1::INSTR').
+        """
         self.box = SerialDriver(serial_port)
         self.inst = VisaDriver(visa_address)
         print(f"Connected to UUT System on {serial_port} & {visa_address}")
 
     def mes_voltage(self, port_number):
-        """
-        User command: Measures voltage on a specific UUT port.
+        """User command: Measures voltage on a specific UUT port.
+
+        Args:
+            port_number (int): The port number on the multiplexer to switch to.
+
+        Returns:
+            float: The measured voltage in Volts. Returns 0.0 if value conversion fails.
         """
         # 1. Switch the Multiplexer/Box to the correct port
         print(f"Switching Relay to Port {port_number}...")
@@ -34,5 +50,6 @@ class UUTHandler:
             return 0.0
 
     def close(self):
+        """Closes connections to both the box and the instrument."""
         self.box.close()
         self.inst.close()

--- a/src/instrumation/drivers/base.py
+++ b/src/instrumation/drivers/base.py
@@ -1,10 +1,18 @@
 from abc import ABC, abstractmethod
 
 class InstrumentDriver(ABC):
-    """
-    Abstract Base Class for Generic Instruments.
+    """Abstract Base Class for Generic Instruments.
+
+    Attributes:
+        resource: The underlying resource object or connection string.
+        connected (bool): Connection status of the instrument.
     """
     def __init__(self, resource):
+        """Initializes the InstrumentDriver.
+
+        Args:
+            resource: The resource to connect to.
+        """
         self.resource = resource
         self.connected = False
 
@@ -15,47 +23,83 @@ class InstrumentDriver(ABC):
 
     @abstractmethod
     def disconnect(self):
-        """Closes the connection."""
+        """Closes the connection to the instrument."""
         pass
 
     @abstractmethod
     def get_id(self) -> str:
-        """Returns the identification string of the instrument."""
+        """Returns the identification string of the instrument.
+
+        Returns:
+            str: The identification string.
+        """
         pass
 
     @abstractmethod
     def measure_frequency(self) -> float:
-        """Measures the frequency of the input signal."""
+        """Measures the frequency of the input signal.
+
+        Returns:
+            float: The measured frequency in Hz.
+        """
         pass
 
     @abstractmethod
     def measure_duty_cycle(self) -> float:
-        """Measures the duty cycle of the input signal as a percentage."""
+        """Measures the duty cycle of the input signal as a percentage.
+
+        Returns:
+            float: The duty cycle in percent (0-100).
+        """
         pass
 
     @abstractmethod
     def measure_v_peak_to_peak(self) -> float:
-        """Measures the peak-to-peak voltage of the input signal."""
+        """Measures the peak-to-peak voltage of the input signal.
+
+        Returns:
+            float: The peak-to-peak voltage in Volts.
+        """
         pass
 
 class Multimeter(InstrumentDriver):
     """Abstract Base Class for Digital Multimeters."""
     @abstractmethod
     def measure_voltage(self) -> float:
+        """Measures the DC voltage.
+
+        Returns:
+            float: The measured voltage in Volts.
+        """
         pass
     
     @abstractmethod
     def measure_resistance(self) -> float:
+        """Measures the resistance.
+
+        Returns:
+            float: The measured resistance in Ohms.
+        """
         pass
 
 class PowerSupply(InstrumentDriver):
     """Abstract Base Class for DC Power Supplies."""
     @abstractmethod
     def set_voltage(self, voltage: float):
+        """Sets the output voltage.
+
+        Args:
+            voltage (float): The voltage level to set in Volts.
+        """
         pass
     
     @abstractmethod
     def get_current(self) -> float:
+        """Reads the current output current.
+
+        Returns:
+            float: The measured current in Amperes.
+        """
         pass
 
 class SpectrumAnalyzer(InstrumentDriver):
@@ -67,11 +111,19 @@ class SpectrumAnalyzer(InstrumentDriver):
 
     @abstractmethod
     def get_marker_amplitude(self) -> float:
-        """Returns the amplitude at the current marker."""
+        """Returns the amplitude at the current marker.
+
+        Returns:
+            float: The amplitude value (e.g., in dBm).
+        """
         pass
 
     def get_peak_value(self) -> float:
-        """Helper: Performs peak search and returns amplitude."""
+        """Helper: Performs peak search and returns amplitude.
+
+        Returns:
+            float: The peak amplitude value.
+        """
         self.peak_search()
         return self.get_marker_amplitude()
 
@@ -79,17 +131,39 @@ class NetworkAnalyzer(InstrumentDriver):
     """Abstract Base Class for Vector Network Analyzers."""
     @abstractmethod
     def set_start_frequency(self, freq_hz: float):
+        """Sets the start frequency for the sweep.
+
+        Args:
+            freq_hz (float): The start frequency in Hz.
+        """
         pass
 
     @abstractmethod
     def set_stop_frequency(self, freq_hz: float):
+        """Sets the stop frequency for the sweep.
+
+        Args:
+            freq_hz (float): The stop frequency in Hz.
+        """
         pass
 
     @abstractmethod
     def set_points(self, num_points: int):
+        """Sets the number of points for the sweep.
+
+        Args:
+            num_points (int): The number of measurement points.
+        """
         pass
 
     @abstractmethod
     def get_trace_data(self, measurement_name: str) -> list[float]:
-        """Returns the formatted data trace."""
+        """Returns the formatted data trace.
+
+        Args:
+            measurement_name (str): The name of the measurement/trace to retrieve.
+
+        Returns:
+            list[float]: The trace data points.
+        """
         pass


### PR DESCRIPTION
This PR updates the docstrings in src/instrumation/drivers/base.py and src/instrumation/device.py to follow the Google-style format, as requested in issue #3.