### PR TITLE
refactor: Add Oscilloscope Abstract Base Class

### DIFF
--- a/src/instrumation/drivers/base.py
+++ b/src/instrumation/drivers/base.py
@@ -167,3 +167,32 @@ class NetworkAnalyzer(InstrumentDriver):
             list[float]: The trace data points.
         """
         pass
+
+class Oscilloscope(InstrumentDriver):
+    """Abstract Base Class for Oscilloscopes."""
+    @abstractmethod
+    def run(self):
+        """Starts acquisition."""
+        pass
+
+    @abstractmethod
+    def stop(self):
+        """Stops acquisition."""
+        pass
+
+    @abstractmethod
+    def single(self):
+        """Sets the oscilloscope to single acquisition mode."""
+        pass
+
+    @abstractmethod
+    def get_waveform(self, channel: int) -> list[float]:
+        """Returns the waveform data for the specified channel.
+
+        Args:
+            channel (int): The channel number to read from.
+
+        Returns:
+            list[float]: The waveform data points.
+        """
+        pass


### PR DESCRIPTION
This PR introduces an abstract base class for Oscilloscopes, defining a common interface for interacting with different oscilloscope models. This will facilitate the development of new oscilloscope drivers and promote code reusability.