### PR TITLE
feat: add DataBroadcaster for live UDP data streaming (closes #38)

### DIFF
--- a/.github/workflows/test_broadcaster.yml
+++ b/.github/workflows/test_broadcaster.yml
@@ -1,0 +1,42 @@
+name: Test DataBroadcaster (Issue #38)
+
+on:
+  push:
+    branches:
+      - "claude/**"
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test-broadcaster:
+    runs-on: ubuntu-latest
+    env:
+      INSTRUMATION_MODE: SIM
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -e .
+
+      - name: Lint DataBroadcaster (syntax + undefined names)
+        run: |
+          pip install flake8
+          flake8 src/instrumation/utils.py --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 tests/test_broadcaster.py --count --select=E9,F63,F7,F82 --show-source --statistics
+
+      - name: Run DataBroadcaster tests
+        run: |
+          pytest tests/test_broadcaster.py -v
+
+      - name: Run full test suite (regression check)
+        run: |
+          pytest -v

--- a/src/instrumation/__init__.py
+++ b/src/instrumation/__init__.py
@@ -1,6 +1,7 @@
 from .scanner import scan
 from .device import UUTHandler
 from .station import Station
+from .utils import DataBroadcaster
 import pyvisa
 from .drivers.keysight import KeysightMXA
 from .drivers.rigol import RigolDSA

--- a/src/instrumation/utils.py
+++ b/src/instrumation/utils.py
@@ -1,6 +1,58 @@
 import csv
+import json
 import os
+import socket
 from datetime import datetime
+
+
+class DataBroadcaster:
+    """
+    Broadcasts instrument data over UDP as JSON packets.
+
+    Useful for streaming live readings to dashboards, loggers, or other
+    listeners on the network with zero external dependencies.
+
+    Usage::
+
+        broadcaster = DataBroadcaster(host="127.0.0.1", port=5005)
+        broadcaster.send({"voltage": 3.3, "current": 0.5})
+        broadcaster.close()
+
+    Or as a context manager::
+
+        with DataBroadcaster() as b:
+            b.send({"peak_power": -45.2})
+    """
+
+    def __init__(self, host="127.0.0.1", port=5005):
+        self.host = host
+        self.port = port
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def send(self, data):
+        """
+        Serialize *data* (dict or list) to JSON and send it as a UDP packet.
+        Silently ignores transmission errors so the test flow is never interrupted.
+        """
+        try:
+            payload = json.dumps(data).encode("utf-8")
+            self._sock.sendto(payload, (self.host, self.port))
+        except Exception:
+            pass
+
+    def close(self):
+        """Close the underlying UDP socket."""
+        try:
+            self._sock.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
 
 class TestLogger:
     def __init__(self, filename="test_report.csv"):

--- a/tests/test_broadcaster.py
+++ b/tests/test_broadcaster.py
@@ -1,0 +1,107 @@
+import json
+import socket
+import threading
+import time
+import unittest
+
+from instrumation.utils import DataBroadcaster
+
+
+def _listen_once(host, port, timeout=2.0):
+    """Helper: bind a UDP socket, receive one packet, return decoded JSON."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.settimeout(timeout)
+    sock.bind((host, port))
+    try:
+        data, _ = sock.recvfrom(65535)
+        return json.loads(data.decode("utf-8"))
+    finally:
+        sock.close()
+
+
+class TestDataBroadcaster(unittest.TestCase):
+    PORT = 59876  # high ephemeral port unlikely to conflict
+
+    def test_send_dict(self):
+        """DataBroadcaster sends a dict that a UDP listener can receive and decode."""
+        result = {}
+
+        def listen():
+            result["payload"] = _listen_once("127.0.0.1", self.PORT)
+
+        t = threading.Thread(target=listen, daemon=True)
+        t.start()
+        time.sleep(0.05)  # let listener bind before sending
+
+        with DataBroadcaster(host="127.0.0.1", port=self.PORT) as b:
+            b.send({"voltage": 3.3, "current": 0.5})
+
+        t.join(timeout=3)
+        self.assertEqual(result.get("payload"), {"voltage": 3.3, "current": 0.5})
+
+    def test_send_list(self):
+        """DataBroadcaster can send a list payload."""
+        result = {}
+
+        def listen():
+            result["payload"] = _listen_once("127.0.0.1", self.PORT + 1)
+
+        t = threading.Thread(target=listen, daemon=True)
+        t.start()
+        time.sleep(0.05)
+
+        with DataBroadcaster(host="127.0.0.1", port=self.PORT + 1) as b:
+            b.send([-45.2, -46.1, -44.8])
+
+        t.join(timeout=3)
+        self.assertEqual(result.get("payload"), [-45.2, -46.1, -44.8])
+
+    def test_silent_on_error(self):
+        """send() must not raise even when the socket is already closed."""
+        b = DataBroadcaster(host="127.0.0.1", port=self.PORT + 2)
+        b.close()
+        # Should not raise
+        b.send({"should": "not crash"})
+
+    def test_context_manager(self):
+        """DataBroadcaster works as a context manager and closes cleanly."""
+        with DataBroadcaster(host="127.0.0.1", port=self.PORT + 3) as b:
+            self.assertIsNotNone(b._sock)
+        # After __exit__ the socket fd should be closed; sending must not raise
+        b.send({"after": "close"})
+
+    def test_multiple_sends(self):
+        """Multiple send() calls on one broadcaster all arrive correctly."""
+        received = []
+
+        def listen():
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.settimeout(2.0)
+            sock.bind(("127.0.0.1", self.PORT + 4))
+            try:
+                for _ in range(3):
+                    data, _ = sock.recvfrom(65535)
+                    received.append(json.loads(data.decode("utf-8")))
+            except socket.timeout:
+                pass
+            finally:
+                sock.close()
+
+        t = threading.Thread(target=listen, daemon=True)
+        t.start()
+        time.sleep(0.05)
+
+        with DataBroadcaster(host="127.0.0.1", port=self.PORT + 4) as b:
+            b.send({"reading": 1})
+            b.send({"reading": 2})
+            b.send({"reading": 3})
+
+        t.join(timeout=3)
+        self.assertEqual(len(received), 3)
+        self.assertEqual([r["reading"] for r in received], [1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #38
Adds a zero-dependency DataBroadcaster class to utils.py that streams
instrument readings as JSON over UDP. Supports dict/list payloads,
context manager usage, and silently swallows transmission errors so
the test flow is never interrupted.

- src/instrumation/utils.py: new DataBroadcaster class
- src/instrumation/__init__.py: export DataBroadcaster at package level
- tests/test_broadcaster.py: 5 unit tests (send dict, list, error
  resilience, context manager, multiple sends via threaded listener)
- .github/workflows/test_broadcaster.yml: dedicated CI workflow that
  runs on claude/* branches for rapid feedback during development

https://claude.ai/code/session_0146owvCWSXcZjzxS4jD1ohn