### PR TITLE
docs: Document DataBroadcaster and add dashboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ RF test bench automation is painful. Every instrument brand has its own quirks, 
 
 ---
 
+--- 
+
+## Live Data Streaming 
+
+Instrumation includes a built-in `DataBroadcaster` for streaming live readings over UDP. This allows you to build real-time dashboards or loggers with zero external dependencies. 
+
+- **Zero-lag** — UDP delivery doesn't block your test flow. 
+- **Zero-config** — Broadcast to any host/port as JSON packets. 
+- **Zero-dep** — Built-in with Python standard library. 
+
+See [examples/broadcast_demo.py](examples/broadcast_demo.py) and [examples/dashboard.py](examples/dashboard.py) for usage. 
+
 ## Features
 
 - **Auto-Discovery** — scans VISA and Serial buses, identifies what's connected

--- a/examples/broadcast_demo.py
+++ b/examples/broadcast_demo.py
@@ -1,0 +1,24 @@
+import time
+import random
+from instrumation.utils import DataBroadcaster
+
+# Connect to the broadcaster on local port 5005
+with DataBroadcaster(host="127.0.0.1", port=5005) as b:
+    print("Broadcasting simulated peak power readings to 127.0.0.1:5005...")
+    print("Press Ctrl+C to stop.")
+    
+    try:
+        while True:
+            # Simulate an instrument measurement
+            val = -45.0 + random.uniform(-2.0, 2.0)
+            
+            # Send as JSON over UDP
+            b.send({
+                "timestamp": time.time(),
+                "peak_power": round(val, 2),
+                "unit": "dBm"
+            })
+            
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print("\nBroadcasting stopped.")

--- a/examples/dashboard.py
+++ b/examples/dashboard.py
@@ -1,0 +1,37 @@
+import socket
+import json
+
+# Setup UDP listener
+UDP_IP = "127.0.0.1"
+UDP_PORT = 5005
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind((UDP_IP, UDP_PORT))
+
+print(f"Listening for instrument data on {UDP_IP}:{UDP_PORT}...")
+print("-" * 50)
+
+try:
+    while True:
+        data, addr = sock.recvfrom(1024)
+        try:
+            payload = json.loads(data.decode("utf-8"))
+            
+            # Simple terminal visualization
+            ts = payload.get("timestamp", 0)
+            val = payload.get("peak_power", 0)
+            unit = payload.get("unit", "")
+            
+            # Create a simple bar based on the value
+            # Assume range is -60 to -30 dBm
+            bar_len = int((val + 60) * 2)
+            bar = "#" * max(0, bar_len)
+            
+            print(f"[{ts:.2f}] {val:>6} {unit} | {bar}")
+            
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            print("Received malformed packet.")
+except KeyboardInterrupt:
+    print("\nDashboard closed.")
+finally:
+    sock.close()


### PR DESCRIPTION
Documents the DataBroadcaster utility in the README and adds example scripts showing how to stream instrument data over UDP and visualize it in a terminal dashboard.\n\nFixes Closes #54