### PR TITLE
Add measure_temperature to SimulatedMultimeter

### DIFF
--- a/src/instrumation/drivers/simulated.py
+++ b/src/instrumation/drivers/simulated.py
@@ -66,9 +66,11 @@ class SimulatedMultimeter(SimulatedBaseDriver, Multimeter):
     def measure_resistance(self, four_wire: bool = False): 
         time.sleep(self.latency)
         return MeasurementResult(1000.0, "Ohm")
-    def measure_current(self, ac: bool = False): 
+    def measure_current(self, ac: bool = False):
         time.sleep(self.latency)
         return MeasurementResult(0.01, "A")
+    def measure_temperature(self, probe_type="TC", probe="K"):
+        return MeasurementResult(23.5, "C")
     def set_auto_range(self, state): pass
 
 @register_driver("PSU")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -149,6 +149,20 @@ class TestSimulation(unittest.TestCase):
             res = dmm.measure_voltage()
             self.assertIsInstance(res, MeasurementResult)
 
+    def test_simulated_multimeter_measure_temperature(self):
+        """Base SimulatedMultimeter should expose measure_temperature.
+
+        The factory returns SimulatedMultimeter (not the Keysight subclass)
+        when no specific model is requested, so the base class needs the
+        method too — otherwise SIM_DMM crashes with AttributeError.
+        """
+        from instrumation.drivers.simulated import SimulatedMultimeter
+        dmm = SimulatedMultimeter("SIM::DMM")
+        t = dmm.measure_temperature()
+        self.assertIsInstance(t, MeasurementResult)
+        self.assertEqual(t.value, 23.5)
+        self.assertEqual(t.unit, "C")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #68

The factory returns `SimulatedMultimeter` (the base class, not the Keysight subclass) when `SIM_DMM` is requested without a specific model. The Keysight subclass has `measure_temperature`, the base class doesn't, so any factory-built DMM crashes with `AttributeError` the moment you try to read a temperature.

Reproduced before the fix:
```
>>> from instrumation.drivers.simulated import SimulatedMultimeter
>>> SimulatedMultimeter('SIM::DMM').measure_temperature()
AttributeError: 'SimulatedMultimeter' object has no attribute 'measure_temperature'
```

Change: two lines in `src/instrumation/drivers/simulated.py`, inserted between `measure_current` and `set_auto_range`. Signature copied from the existing Keysight implementation so behavior is consistent across the hierarchy.

Also added a small test in `tests/test_simulation.py` that instantiates the base class directly and checks the return — this is the case the existing Keysight test doesn't cover.

`pytest tests/test_simulation.py -v` — 8 passed (was 7).
Full `pytest tests/` unchanged otherwise (the two existing async failures are pre-existing, missing `pytest-asyncio` plugin).