### PR TITLE
log output state changes in SimulatedPowerSupply.set_output

### DIFF
--- a/src/instrumation/drivers/simulated.py
+++ b/src/instrumation/drivers/simulated.py
@@ -91,7 +91,9 @@ class SimulatedPowerSupply(SimulatedBaseDriver, PowerSupply):
         time.sleep(self.latency)
         return MeasurementResult(0.0, "A")
     def get_current_limit(self) -> float: return 0.0
-    def set_output(self, state: bool): self._output = state
+    def set_output(self, state: bool):
+        print(f"[SIM] PSU Output: {'ON' if state else 'OFF'}")
+        self._output = state
     def get_output(self) -> bool: return getattr(self, "_output", False)
     def set_ovp(self, voltage: float): pass
     def set_ocp(self, current: float): pass


### PR DESCRIPTION
Closes #79 

Added a print line to SimulatedPowerSupply.set_output so output changes are visible in the simulator, similar to set_voltage.