### PR TITLE
install test extras in contributing setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To set up your local development environment:
 2.  **Install in editable mode**:
     This allows you to test your changes immediately without re-installing.
     ```bash
-    pip install -e .
+    pip install -e ".[test]"
     ```
 
 ## Digital Twin Mode


### PR DESCRIPTION
Follow-up to #79 

Updated CONTRIBUTING.md to use pip install -e ".[test]" so a fresh venv installs the needed test dependencies, including pytest-asyncio.
Using `pip install -e ".[test]"` installs pytest and pytest-asyncio (both already declared in pyproject.toml) so the test suite passes out of the box