### PR TITLE
chore: remove dead SimulatedDriver stub

### DIFF
--- a/src/instrumation/drivers/simulated.py
+++ b/src/instrumation/drivers/simulated.py
@@ -601,7 +601,3 @@ class SimulatedFrequencyCounter(SimulatedBaseDriver, FrequencyCounter):
     def set_auto_range(self, state: bool):
         self._auto_range = state
         print(f"[SIM] Counter Auto Range: {'ON' if state else 'OFF'}")
-
-
-class SimulatedDriver(SimulatedMultimeter):
-    pass


### PR DESCRIPTION
## Summary
- Remove the unused `SimulatedDriver` stub from `src/instrumation/drivers/simulated.py`.
- Leave the existing simulated driver exports unchanged.

## Verification
- `git diff --check`
- `INSTRUMATION_MODE=SIM flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `INSTRUMATION_MODE=SIM python -m pytest -q` (`156 passed`)

Prepared by an AI coding agent under operator approval.

Closes #96