### PR TITLE
fix: simulate PSU foldback/autostart state tracking

### DIFF
--- a/src/instrumation/drivers/simulated.py
+++ b/src/instrumation/drivers/simulated.py
@@ -82,6 +82,12 @@ class SimulatedMultimeter(SimulatedBaseDriver, Multimeter):
 
 @register_driver("PSU")
 class SimulatedPowerSupply(SimulatedBaseDriver, PowerSupply):
+    def __init__(self, resource: str, latency: float = 0.01):
+        super().__init__(resource, latency)
+        self._foldback_mode = "OFF"
+        self._foldback_delay = 0.0
+        self._autostart = False
+
     def set_voltage(self, voltage: float): 
         print(f"[SIM] Setting PSU Voltage: {voltage}")
         self._voltage = voltage
@@ -107,9 +113,15 @@ class SimulatedPowerSupply(SimulatedBaseDriver, PowerSupply):
         print("[SIM] PSU Protection Cleared")
     def measure_power(self) -> MeasurementResult:
         return MeasurementResult(getattr(self, "_voltage", 0.0) * 0.5, "W")
-    def set_foldback_mode(self, mode: str): pass
-    def set_foldback_delay(self, seconds: float): pass
-    def set_autostart(self, state: bool): pass
+    def set_foldback_mode(self, mode: str):
+        self._foldback_mode = mode
+        print(f"[SIM] PSU Foldback Mode: {mode}")
+    def set_foldback_delay(self, seconds: float):
+        self._foldback_delay = seconds
+        print(f"[SIM] PSU Foldback Delay: {seconds} s")
+    def set_autostart(self, state: bool):
+        self._autostart = state
+        print(f"[SIM] PSU Autostart: {'ON' if state else 'OFF'}")
     def get_mode(self) -> str: return "CV"
 
 @register_driver("SA")

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -222,6 +222,32 @@ class TestSimulation(unittest.TestCase):
 
         psu.disconnect()
 
+    def test_simulated_powersupply_foldback_and_autostart_stubs(self):
+        """Issue #101: verify foldback/autostart state is tracked in SimulatedPowerSupply."""
+        from instrumation.drivers.simulated import SimulatedPowerSupply
+        psu = SimulatedPowerSupply("USB::SIM::PSU", latency=0)
+        psu.connect()
+
+        self.assertEqual(psu._foldback_mode, "OFF")
+        self.assertEqual(psu._foldback_delay, 0.0)
+        self.assertFalse(psu._autostart)
+
+        psu.set_foldback_mode("CC")
+        psu.set_foldback_delay(2.5)
+        psu.set_autostart(True)
+
+        self.assertEqual(psu._foldback_mode, "CC")
+        self.assertEqual(psu._foldback_delay, 2.5)
+        self.assertTrue(psu._autostart)
+
+        psu.set_foldback_mode("CV")
+        self.assertEqual(psu._foldback_mode, "CV")
+
+        psu.set_autostart(False)
+        self.assertFalse(psu._autostart)
+
+        psu.disconnect()
+
     def test_simulated_scope_set_trigger_stub(self):
         """Issue #84: Verify set_trigger doesn't crash on SimulatedOscilloscope."""
         from instrumation.drivers.simulated import SimulatedOscilloscope


### PR DESCRIPTION
## Summary\n- implement state tracking and simulation logging for power-supply foldback/autostart settings in SimulatedPowerSupply\n- initialize foldback mode, delay, and autostart defaults in constructor\n- add tests for new state behavior and defaults in tests/test_simulation.py\n\n## Validation\n- INSTRUMATION_MODE=SIM pytest tests/test_simulation.py -k powersupply\n- flake8 src/instrumation/drivers/simulated.py tests/test_simulation.py --count --select=E9,F63,F7,F82\n\n## Issue\nCloses #101