### PR TITLE
Add print logging stubs to SimulatedNetworkAnalyzer configuration methods

### DIFF
--- a/src/instrumation/drivers/simulated.py
+++ b/src/instrumation/drivers/simulated.py
@@ -191,16 +191,26 @@ class SimulatedSpectrumAnalyzer(SimulatedBaseDriver, SpectrumAnalyzer):
 @register_driver("NA")
 @register_driver("VNA")
 class SimulatedNetworkAnalyzer(SimulatedBaseDriver, NetworkAnalyzer):
-    def set_start_frequency(self, freq_hz): pass
-    def set_stop_frequency(self, freq_hz): pass
-    def set_center_frequency(self, freq_hz): pass
-    def set_span(self, span_hz): pass
-    def set_points(self, num_points): pass
-    def set_if_bandwidth(self, hz: float): pass
-    def set_power_level(self, dbm: float): pass
-    def set_sweep_type(self, sweep_type: str): pass
-    def set_averaging(self, state: bool, count: int = 10): pass
-    def set_continuous(self, state: bool): pass
+    def set_start_frequency(self, freq_hz):
+        print(f"[SIM] VNA Start Frequency: {freq_hz} Hz")
+    def set_stop_frequency(self, freq_hz):
+        print(f"[SIM] VNA Stop Frequency: {freq_hz} Hz")
+    def set_center_frequency(self, freq_hz):
+        print(f"[SIM] VNA Center Frequency: {freq_hz} Hz")
+    def set_span(self, span_hz):
+        print(f"[SIM] VNA Span: {span_hz} Hz")
+    def set_points(self, num_points):
+        print(f"[SIM] VNA Points: {num_points}")
+    def set_if_bandwidth(self, hz: float):
+        print(f"[SIM] VNA IF Bandwidth: {hz} Hz")
+    def set_power_level(self, dbm: float):
+        print(f"[SIM] VNA Power Level: {dbm} dBm")
+    def set_sweep_type(self, sweep_type: str):
+        print(f"[SIM] VNA Sweep Type: {sweep_type}")
+    def set_averaging(self, state: bool, count: int = 10):
+        print(f"[SIM] VNA Averaging: {'ON' if state else 'OFF'}, count={count}")
+    def set_continuous(self, state: bool):
+        print(f"[SIM] VNA Continuous: {'ON' if state else 'OFF'}")
     def set_parameter(self, parameter: str):
         print(f"[SIM] VNA Setting Parameter: {parameter}")
     def get_trace_data(self, measurement_name: str = "CH1_S11_1"): 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -312,6 +312,46 @@ class TestSimulation(unittest.TestCase):
 
         scope.disconnect()
 
+    def test_simulated_vna_configuration_stubs_logging(self):
+        """Verify configuration methods on SimulatedNetworkAnalyzer log to stdout."""
+        import io
+        import sys
+        from instrumation.drivers.simulated import SimulatedNetworkAnalyzer
+
+        vna = SimulatedNetworkAnalyzer("USB::SIM::VNA", latency=0)
+        vna.connect()
+
+        # Capture stdout
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        try:
+            vna.set_start_frequency(1e6)
+            vna.set_stop_frequency(2e6)
+            vna.set_center_frequency(1.5e6)
+            vna.set_span(1e6)
+            vna.set_points(201)
+            vna.set_if_bandwidth(1000.0)
+            vna.set_power_level(-10.0)
+            vna.set_sweep_type("linear")
+            vna.set_averaging(True, count=5)
+            vna.set_continuous(False)
+        finally:
+            sys.stdout = sys.__stdout__
+
+        output = captured_output.getvalue()
+        self.assertIn("[SIM] VNA Start Frequency: 1000000.0 Hz", output)
+        self.assertIn("[SIM] VNA Stop Frequency: 2000000.0 Hz", output)
+        self.assertIn("[SIM] VNA Center Frequency: 1500000.0 Hz", output)
+        self.assertIn("[SIM] VNA Span: 1000000.0 Hz", output)
+        self.assertIn("[SIM] VNA Points: 201", output)
+        self.assertIn("[SIM] VNA IF Bandwidth: 1000.0 Hz", output)
+        self.assertIn("[SIM] VNA Power Level: -10.0 dBm", output)
+        self.assertIn("[SIM] VNA Sweep Type: linear", output)
+        self.assertIn("[SIM] VNA Averaging: ON, count=5", output)
+        self.assertIn("[SIM] VNA Continuous: OFF", output)
+
+        vna.disconnect()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

This PR implements print logging stubs for the 10 configuration methods in `SimulatedNetworkAnalyzer` in `src/instrumation/drivers/simulated.py`.
Currently, these methods are silent `pass` stubs, whereas other simulated drivers in the codebase log their actions with a `[SIM]` prefix.

Adding these prints ensures consistent logging across all simulated instrument drivers and allows downstream scripts/tests to verify instrument configuration sequences.

## Changes
- Replaced `pass` stubs with print logs in `SimulatedNetworkAnalyzer` configuration methods.
- Added `test_simulated_vna_configuration_stubs_logging` in `tests/test_simulation.py` to assert correct logging formats and parameters.

Fixes #100