### PR TITLE
Add NumPy-style docstrings to factory public API

### DIFF
--- a/src/instrumation/factory.py
+++ b/src/instrumation/factory.py
@@ -1,3 +1,10 @@
+"""Driver factory and instrument discovery.
+
+Resolves a resource address into a connected instrument driver, handling replay
+files, simulated instruments, auto-discovery and real hardware behind a single
+entry point, :func:`get_instrument`.
+"""
+
 import pyvisa
 import logging
 import os
@@ -12,6 +19,21 @@ logger = logging.getLogger(__name__)
 _GLOBAL_RM = None
 
 def get_rm():
+    """Return the process-wide PyVISA resource manager, creating it on first use.
+
+    A single :class:`pyvisa.ResourceManager` is cached for the lifetime of the
+    process. Opening several managers causes "Too many managers" errors on
+    macOS, so every caller shares this one.
+
+    On macOS the NI-VISA framework at
+    ``/Library/Frameworks/VISA.framework/VISA`` is requested explicitly when
+    that path exists; otherwise PyVISA selects its own backend.
+
+    Returns
+    -------
+    pyvisa.ResourceManager
+        The shared resource manager instance.
+    """
     global _GLOBAL_RM
     if _GLOBAL_RM is None:
         ni_lib = "/Library/Frameworks/VISA.framework/VISA"
@@ -20,6 +42,17 @@ def get_rm():
     return _GLOBAL_RM
 
 def is_sim_mode() -> bool:
+    """Report whether simulation (digital twin) mode is enabled.
+
+    Simulation mode is controlled by the ``INSTRUMATION_MODE`` environment
+    variable and the comparison is case-insensitive.
+
+    Returns
+    -------
+    bool
+        ``True`` when ``INSTRUMATION_MODE`` is ``"SIM"`` or ``"SIMULATED"``,
+        ``False`` otherwise.
+    """
     mode = os.environ.get("INSTRUMATION_MODE", "").upper()
     return mode == "SIM" or mode == "SIMULATED"
 
@@ -61,6 +94,55 @@ def _discover_mdns_resources() -> list:
     return resources
 
 def get_instrument(resource_address: str, driver_type: str = "GENERIC") -> any:
+    """Connect to an instrument and return a driver instance for it.
+
+    The address is resolved in priority order:
+
+    1. **Replay** -- an address beginning with ``replay://`` returns a
+       ``ReplayDriver`` that reads from the file named after the prefix.
+    2. **Simulation** -- when :func:`is_sim_mode` is true, a simulated driver
+       registered for ``driver_type`` is returned instead of touching hardware.
+    3. **Auto-discovery** -- the literal address ``"AUTO"`` searches for a
+       matching instrument, trying the on-disk cache first, then mDNS, then the
+       LAN ARP table, then a full VISA scan.
+    4. **Real hardware** -- any other address is opened directly, identified via
+       ``*IDN?``, and routed to the matching vendor driver.
+
+    Parameters
+    ----------
+    resource_address : str
+        A VISA resource string such as ``"TCPIP::192.168.1.5::INSTR"``, a
+        ``replay://`` file path, or the literal ``"AUTO"`` to auto-discover.
+    driver_type : str, optional
+        Instrument category used to select and validate the driver. One of
+        ``"SCOPE"``, ``"SA"``, ``"SG"``, ``"PSU"``, ``"DMM"``, ``"VNA"``,
+        ``"NA"``, ``"LOAD"``, ``"ELOAD"``, ``"COUNTER"`` or ``"GENERIC"``.
+        Defaults to ``"GENERIC"``, which accepts any instrument.
+
+    Returns
+    -------
+    object
+        A connected driver instance. The concrete class depends on which
+        instrument was identified.
+
+    Raises
+    ------
+    ValueError
+        If simulation mode is active, ``driver_type`` is not ``"GENERIC"`` and
+        no simulated driver is registered for that type; or if ``"AUTO"``
+        discovery finds no matching instrument.
+
+    Notes
+    -----
+    Resources found through ``"AUTO"`` discovery are written to
+    ``.visa_cache.json`` in the working directory, most recent first, so later
+    lookups try them before falling back to a full scan.
+
+    Examples
+    --------
+    >>> dmm = get_instrument("TCPIP::192.168.1.5::INSTR", "DMM")
+    >>> scope = get_instrument("AUTO", "SCOPE")
+    """
     # 0. Check for replay mode (Highest Priority)
     if resource_address.startswith("replay://"):
         file_path = resource_address.replace("replay://", "")
@@ -304,6 +386,31 @@ def get_instrument(resource_address: str, driver_type: str = "GENERIC") -> any:
     return final_drv
 
 def get_instrument_from_config(config: dict) -> any:
+    """Connect to an instrument described by a configuration mapping.
+
+    A thin wrapper over :func:`get_instrument` for config-driven setups such as
+    station definitions loaded from disk.
+
+    Parameters
+    ----------
+    config : dict
+        Must contain ``"address"`` -- a VISA resource string or ``"AUTO"`` --
+        and ``"type"``, the driver category passed through as ``driver_type``.
+
+    Returns
+    -------
+    object
+        A connected driver instance, as returned by :func:`get_instrument`.
+
+    Raises
+    ------
+    ValueError
+        If either ``"address"`` or ``"type"`` is missing from ``config``.
+
+    Examples
+    --------
+    >>> get_instrument_from_config({"address": "AUTO", "type": "SCOPE"})
+    """
     resource_address = config.get("address")
     driver_type = config.get("type") # Mandatory for test compatibility
     if not resource_address:


### PR DESCRIPTION
Addresses the "Add NumPy-style docstrings to public API" issue.

Scoped to `src/instrumation/factory.py` for a reviewable first pass. `get_instrument` and `get_instrument_from_config` are two of the seven names exported in `__all__`, so this covers a real slice of the public surface rather than a scattered sample.

**What's documented**

- module docstring explaining what the factory resolves
- `get_rm` — why the resource manager is a process-wide singleton (the "Too many managers" issue on macOS) and the NI-VISA framework path behaviour
- `is_sim_mode` — which `INSTRUMATION_MODE` values enable simulation
- `get_instrument` — the four-way resolution order (replay → simulation → AUTO discovery → real hardware), the full `driver_type` vocabulary, both conditions that raise `ValueError`, and the `.visa_cache.json` behaviour
- `get_instrument_from_config` — required keys and the errors raised when either is absent

**Scope**

Documentation only. No behaviour changed, no code touched — the diff is 107 insertions and 0 deletions.

Happy to extend the same treatment to `transport.py`, `device.py` and `utils.py` if this style is what you want. I deliberately kept it to one file so the convention can be agreed before it's applied more widely.

---

I also found one genuine bug while reading `get_instrument` closely enough to document it — `import json` is scoped inside the `AUTO` branch, so the cache-update on the manual-connection path raises `UnboundLocalError` and gets swallowed by a bare `except`. Filing that separately rather than mixing a fix into a docs PR.
