### PR TITLE
fix(scanner): handle empty/None input in find_duplicate_addresses

### DIFF
--- a/src/instrumation/scanner.py
+++ b/src/instrumation/scanner.py
@@ -59,7 +59,8 @@ def find_duplicate_addresses(devices: List[Dict[str, str]]) -> List[Dict[str, st
 
     Returns:
         A list of dicts, each with keys "address" (str), "identities" (list
-        of str), and "count" (int).  Empty list if no duplicates found.
+        of str), and "count" (int).  Empty list if no duplicates found, and
+        also for empty or ``None`` input.
 
     Example:
         >>> devices = scan()
@@ -67,6 +68,9 @@ def find_duplicate_addresses(devices: List[Dict[str, str]]) -> List[Dict[str, st
         >>> for c in conflicts:
         ...     print(f"CONFLICT on {c['address']}: {c['identities']}")
     """
+    if not devices:
+        return []
+
     from collections import defaultdict
 
     addr_to_descs = defaultdict(list)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,39 @@
+from instrumation.scanner import find_duplicate_addresses
+
+
+def test_find_duplicate_addresses_empty_list():
+    """Empty input returns an empty list."""
+    assert find_duplicate_addresses([]) == []
+
+
+def test_find_duplicate_addresses_none_input():
+    """None input returns an empty list instead of raising."""
+    assert find_duplicate_addresses(None) == []
+
+
+def test_find_duplicate_addresses_single_device():
+    """A single device can never conflict with itself."""
+    devices = [{"type": "scope", "id": "GPIB0::1", "desc": "Scope A"}]
+    assert find_duplicate_addresses(devices) == []
+
+
+def test_find_duplicate_addresses_all_same_identity():
+    """Same address repeated with the identical description is not a conflict."""
+    devices = [
+        {"type": "scope", "id": "GPIB0::1", "desc": "Scope A"},
+        {"type": "scope", "id": "GPIB0::1", "desc": "Scope A"},
+    ]
+    assert find_duplicate_addresses(devices) == []
+
+
+def test_find_duplicate_addresses_real_conflict():
+    """Same address with differing descriptions is flagged as a conflict."""
+    devices = [
+        {"type": "scope", "id": "GPIB0::1", "desc": "Scope A"},
+        {"type": "load", "id": "GPIB0::1", "desc": "Load B"},
+    ]
+    conflicts = find_duplicate_addresses(devices)
+    assert len(conflicts) == 1
+    assert conflicts[0]["address"] == "GPIB0::1"
+    assert conflicts[0]["count"] == 2
+    assert sorted(conflicts[0]["identities"]) == ["Load B", "Scope A"]


### PR DESCRIPTION
## What
`find_duplicate_addresses()` handled `[]` correctly only by implicit fallthrough (an empty `defaultdict` never populates), and `None` raised `TypeError` when iterated. Adds an explicit early return and documents it.

## Change
- `src/instrumation/scanner.py`: early `if not devices: return []`, docstring updated.
- `tests/test_scanner.py` (new): the four acceptance-criteria cases (empty list, `None`, single device, same-identity duplicates → no conflict), plus a real-conflict case for contrast.

## Verification
- New tests: `pytest tests/test_scanner.py -q` → **5 passed**.
- Full suite: `pytest -q` → **344 passed**, nothing broken.

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)