### PR TITLE
Add NumPy-style docstrings to transport, scanner and utils

### DIFF
--- a/src/instrumation/scanner.py
+++ b/src/instrumation/scanner.py
@@ -1,10 +1,43 @@
+"""Device discovery across serial ports and VISA resources.
+
+Enumerates what is physically attached -- serial ports via ``pyserial`` and VISA
+resources via the shared resource manager -- and reports bus address conflicts
+found in the result.
+"""
+
 import serial.tools.list_ports
 from typing import Dict, List
 
 def scan() -> List[Dict[str, str]]:
-    """
-    Scans for both Serial ports (Control Box) and VISA instruments.
-    Returns a list of dictionaries with device info.
+    """Enumerate attached serial ports and VISA instruments.
+
+    Serial ports are always scanned. The VISA scan is attempted afterwards and
+    skipped with a printed warning if the resource manager is unavailable, so a
+    machine with no VISA backend still returns its serial devices.
+
+    Returns
+    -------
+    list of dict
+        One dict per device, each with keys:
+
+        ``type``
+            ``"serial"`` or ``"visa"``.
+        ``id``
+            The address -- a port path such as ``"COM3"`` or ``"/dev/ttyUSB0"``
+            for serial devices, or a VISA resource string for VISA devices.
+        ``desc``
+            The port description for serial devices, or the literal
+            ``"VISA Instrument"`` for VISA devices.
+
+    Notes
+    -----
+    A VISA scan failure is reported on stdout rather than raised, so an empty
+    or serial-only result does not necessarily mean nothing is connected.
+
+    Examples
+    --------
+    >>> for dev in scan():
+    ...     print(dev["type"], dev["id"], dev["desc"])
     """
     found_devices = []
 

--- a/src/instrumation/transport.py
+++ b/src/instrumation/transport.py
@@ -1,9 +1,48 @@
+"""Low-level transport wrappers and SCPI handshake helpers.
+
+Provides thin connection wrappers for the two physical transports the library
+speaks -- VISA (:class:`VisaDriver`) and raw serial (:class:`SerialDriver`) --
+plus helpers for the handshake problems that come up when talking to real
+instruments: guessing line terminations, finding a workable timeout, and
+waiting for an operation to finish without blind sleeps.
+
+Both wrapper classes are deliberately forgiving: a failed connection leaves the
+object usable but inert rather than raising. See the individual docstrings for
+what that means for callers.
+"""
+
 import serial
 import time
 from typing import List, Optional
 
 class VisaDriver:
-    """Generic wrapper for VISA instruments."""
+    """Generic wrapper for VISA instruments.
+
+    Opens a VISA resource on construction and clears its status register.
+
+    Parameters
+    ----------
+    address : str
+        VISA resource string, for example ``"TCPIP::192.168.1.5::INSTR"``.
+    timeout : int, optional
+        Read timeout in milliseconds, applied to the opened resource.
+        Defaults to ``5000``.
+
+    Notes
+    -----
+    Construction never raises. If the resource cannot be opened, the error is
+    printed and :attr:`inst` is set to ``None``, leaving an object whose methods
+    are all no-ops. Check ``driver.inst is not None`` before relying on it.
+
+    Attributes
+    ----------
+    rm : pyvisa.ResourceManager
+        The shared resource manager from :func:`~instrumation.factory.get_rm`.
+    address : str
+        The resource address this driver was constructed with.
+    inst : pyvisa.Resource or None
+        The open resource, or ``None`` if the connection failed.
+    """
     def __init__(self, address, timeout=5000):
         from .factory import get_rm
         self.rm = get_rm()
@@ -17,6 +56,27 @@ class VisaDriver:
             self.inst = None
 
     def query_value(self, command):
+        """Send a query and return the stripped response.
+
+        Parameters
+        ----------
+        command : str
+            SCPI query to send, for example ``"MEAS:VOLT:DC?"``.
+
+        Returns
+        -------
+        str or float
+            The stripped response string on success. Returns the float ``0.0``
+            if the query raised, or if the driver never connected.
+
+        Notes
+        -----
+        The ``0.0`` fallback is indistinguishable from a genuine ``0.0``
+        reading, and the two failure modes return a different *type* to the
+        success path. Callers that need to tell a real zero from a failed read
+        should check ``self.inst`` first and use the underlying resource
+        directly.
+        """
         if self.inst:
             try:
                 return self.inst.query(command).strip()
@@ -26,16 +86,69 @@ class VisaDriver:
         return 0.0
 
     def write(self, command):
+        """Send a command without reading a response.
+
+        Parameters
+        ----------
+        command : str
+            SCPI command to send, for example ``"OUTP ON"``.
+
+        Notes
+        -----
+        Silently does nothing if the driver never connected. Unlike
+        :meth:`query_value`, write errors are *not* caught and will propagate.
+        """
         if self.inst:
             self.inst.write(command)
 
     def close(self):
+        """Close the VISA resource, leaving the shared resource manager open.
+
+        Safe to call when the driver never connected. The resource manager is
+        a process-wide singleton shared with every other driver, so it is
+        deliberately not closed here.
+        """
         if self.inst:
             self.inst.close()
         # Note: We do NOT close the RM here as it is a global singleton
 
 class SerialDriver:
-    """Generic wrapper for Serial devices."""
+    """Generic wrapper for Serial devices.
+
+    Opens the port on construction and waits two seconds for the device to
+    stabilise, which many USB-serial adapters need before they will accept
+    traffic.
+
+    Parameters
+    ----------
+    port : str
+        Device path or COM port name, for example ``"COM3"`` or
+        ``"/dev/ttyUSB0"``.
+    baudrate : int, optional
+        Baud rate. Defaults to ``9600``.
+    timeout : float, optional
+        Read timeout in seconds. Defaults to ``1``.
+
+    Notes
+    -----
+    Construction never raises. If the port cannot be opened the error is
+    printed and :attr:`ser` is set to ``None``, leaving an object whose methods
+    are all no-ops. Check ``driver.ser is not None`` before relying on it.
+
+    Because of the stabilisation wait, constructing this class blocks for
+    roughly two seconds even when the port opens immediately.
+
+    Attributes
+    ----------
+    port : str
+        Device path or COM port name.
+    baudrate : int
+        Configured baud rate.
+    timeout : float
+        Read timeout in seconds.
+    ser : serial.Serial or None
+        The open port, or ``None`` if it could not be opened.
+    """
     def __init__(self, port, baudrate=9600, timeout=1):
         self.port = port
         self.baudrate = baudrate
@@ -48,6 +161,21 @@ class SerialDriver:
             self.ser = None
 
     def send_command(self, command_str):
+        """Write a command to the port, appending a newline if needed.
+
+        Parameters
+        ----------
+        command_str : str or bytes
+            The command to send. A ``str`` is encoded as UTF-8 and gets a
+            trailing ``\\n`` appended unless it already ends with one. ``bytes``
+            are written through unchanged, with no terminator added.
+
+        Notes
+        -----
+        Silently does nothing if the port never opened, and write errors are
+        caught and printed rather than raised -- so a successful return does
+        not guarantee the command reached the device.
+        """
         if self.ser:
             try:
                 # Handle both bytes and string input
@@ -63,6 +191,20 @@ class SerialDriver:
                 print(f"Serial Write Error: {e}")
 
     def read_response(self):
+        """Read one newline-terminated line and return it stripped.
+
+        Returns
+        -------
+        str
+            The decoded, stripped line. Returns ``""`` on a read error, if the
+            port never opened, or if the read timed out with no data.
+
+        Notes
+        -----
+        An empty string is ambiguous -- it covers a timeout, a decode failure,
+        and a device that genuinely sent a blank line. Blocks up to
+        :attr:`timeout` seconds.
+        """
         if self.ser:
             try:
                 return self.ser.readline().decode('utf-8').strip()
@@ -71,6 +213,7 @@ class SerialDriver:
         return ""
 
     def close(self):
+        """Close the serial port. Safe to call if it never opened."""
         if self.ser:
             self.ser.close()
 

--- a/src/instrumation/utils.py
+++ b/src/instrumation/utils.py
@@ -1,3 +1,14 @@
+"""Output helpers for streaming and recording test data.
+
+Two independent utilities: :class:`DataBroadcaster` pushes readings onto the
+network as UDP JSON for live dashboards, and :class:`TestLogger` appends
+timestamped rows to a CSV report.
+
+Both are built to never interrupt a running test -- errors are swallowed rather
+than raised, which is convenient during a long measurement run and worth knowing
+about when data appears to be missing.
+"""
+
 import csv
 import json
 import os
@@ -11,6 +22,19 @@ class DataBroadcaster:
 
     Useful for streaming live readings to dashboards, loggers, or other
     listeners on the network with zero external dependencies.
+
+    Parameters
+    ----------
+    host : str, optional
+        Destination address. Defaults to ``"127.0.0.1"``.
+    port : int, optional
+        Destination UDP port. Defaults to ``5005``.
+
+    Notes
+    -----
+    UDP is fire-and-forget: the socket is created eagerly and never verifies
+    that anything is listening, so :meth:`send` succeeds whether or not a
+    receiver exists.
 
     Usage::
 
@@ -48,14 +72,48 @@ class DataBroadcaster:
             pass
 
     def __enter__(self):
+        """Return self, so the broadcaster can be used as a context manager."""
         return self
 
     def __exit__(self, *_):
+        """Close the socket on context exit. Exceptions are not suppressed."""
         self.close()
 
 
 class TestLogger:
+    """Append-only CSV logger for test results.
+
+    Writes one row per logged result with columns ``Timestamp``, ``Test Name``,
+    ``Data`` and ``Result``. The header is written once, when the file is first
+    created.
+
+    Parameters
+    ----------
+    filename : str, optional
+        Path to the CSV file. Defaults to ``"test_report.csv"`` in the working
+        directory. An existing file is appended to, not overwritten, so results
+        accumulate across runs.
+
+    Notes
+    -----
+    Each :meth:`log` call opens the file, appends, and closes it. That keeps the
+    report readable while a run is in progress -- and means a long run does many
+    small writes rather than buffering.
+
+    Examples
+    --------
+    >>> logger = TestLogger("run_2026-07-23.csv")
+    >>> logger.log("output_power", -45.2, "PASS")
+    """
+
     def __init__(self, filename="test_report.csv"):
+        """Prepare the log file, writing a header if it does not yet exist.
+
+        Parameters
+        ----------
+        filename : str, optional
+            Path to the CSV file. Defaults to ``"test_report.csv"``.
+        """
         self.filename = filename
         if not os.path.exists(self.filename):
             self._write_header()
@@ -66,6 +124,23 @@ class TestLogger:
             writer.writerow(["Timestamp", "Test Name", "Data", "Result"])
 
     def log(self, test_name, data, result):
+        """Append one timestamped result row and echo it to stdout.
+
+        Parameters
+        ----------
+        test_name : str
+            Identifier for the measurement, used as the ``Test Name`` column.
+        data : any
+            The measured value. Written via ``csv``, so it is stringified --
+            pass a pre-formatted string if you need a specific precision.
+        result : any
+            Pass/fail verdict or status, written to the ``Result`` column.
+
+        Notes
+        -----
+        Also prints ``Logged: <test_name> -> <result>`` to stdout. Write errors
+        are not caught here and will propagate, unlike elsewhere in this module.
+        """
         with open(self.filename, mode='a', newline='') as f:
             writer = csv.writer(f)
             writer.writerow([datetime.now().isoformat(), test_name, data, result])


### PR DESCRIPTION
Follow-up to #134 — the `transport.py`, `scanner.py` and `utils.py` pass you asked for.

Opened as a separate PR rather than pushing onto #134, so that one can merge on its own instead of needing a re-review.

**What's covered**

- **`transport.py`** — module docstring, plus `VisaDriver` and `SerialDriver` and their methods. The module-level handshake helpers (`detect_line_termination`, `find_minimum_timeout`, `poll_for_mav`, `poll_opc_with_backoff`, `batch_query`) were already thoroughly documented, so this just fills in the two transport wrappers.
- **`scanner.py`** — module docstring, and `scan()` converted to NumPy style with the returned dict keys enumerated. `find_duplicate_addresses` was already documented.
- **`utils.py`** — module docstring, `TestLogger` in full, and `DataBroadcaster`'s constructor params and context-manager methods.

Constructor parameters are documented on the class docstring rather than on `__init__`, per NumPy convention, and consistently across all four classes.

**One judgement call worth your eye**

Where behaviour is surprising I documented it plainly instead of glossing it:

- both transport wrappers catch connection errors and leave an *inert but usable* object rather than raising, so callers need to check `.inst` / `.ser`
- `VisaDriver.query_value` returns `0.0` on failure, which is indistinguishable from a genuine `0.0` reading — and is a different type from the success path
- `SerialDriver.__init__` blocks ~2s for the stabilisation sleep
- `SerialDriver.read_response` returns `""` for a timeout, a decode failure, and a genuinely blank line alike

Happy to soften any of that if you'd rather the docs stay neutral — I wrote it the way I'd want to read it as a caller, but it's your project's voice.

Documentation only. No behaviour changed.
