### PR TITLE
fix(factory): create .visa_cache.json on first run via pathlib helper

### DIFF
--- a/src/instrumation/factory.py
+++ b/src/instrumation/factory.py
@@ -1,12 +1,42 @@
 import pyvisa
 import logging
 import os
+import json
 import time
+from pathlib import Path
 from .drivers.real import RealDriver
 from .drivers.registry import DriverRegistry
 from .drivers.base import Oscilloscope, SpectrumAnalyzer, SignalGenerator, FunctionGenerator, PowerSupply, Multimeter, NetworkAnalyzer, ElectronicLoad, FrequencyCounter
 
 logger = logging.getLogger(__name__)
+
+# VISA resource cache. Overridable via INSTRUMATION_CACHE for tests/deployments.
+CACHE_FILE = Path(os.environ.get("INSTRUMATION_CACHE", ".visa_cache.json"))
+
+
+def _read_visa_cache():
+    """Return the cached resource list, creating an empty cache on first use.
+
+    On first run the file does not exist, so AUTO always fell through to the
+    slow full VISA scan. Creating it with an empty list here means subsequent
+    reads hit the cache. Never raises: a missing/corrupt/unwritable cache
+    degrades to an empty list.
+    """
+    try:
+        if not CACHE_FILE.exists():
+            _write_visa_cache([])
+            return []
+        return json.loads(CACHE_FILE.read_text())
+    except (IOError, OSError, ValueError):
+        return []
+
+
+def _write_visa_cache(resources):
+    """Persist the top-10 resources; best-effort, never raises."""
+    try:
+        CACHE_FILE.write_text(json.dumps(resources[:10]))
+    except (IOError, OSError):
+        pass
 
 # Global Resource Manager to prevent "Too many managers" errors on macOS
 _GLOBAL_RM = None
@@ -90,19 +120,11 @@ def get_instrument(resource_address: str, driver_type: str = "GENERIC") -> any:
 
     # 2. Handle AUTO discovery
     if resource_address == "AUTO":
-        import json
         from concurrent.futures import ThreadPoolExecutor, as_completed
-        cache_file = ".visa_cache.json"
-        
+
         # 1. Load Cache & LAN (The Fast Resources)
-        cached_resources = []
-        if os.path.exists(cache_file):
-            try:
-                with open(cache_file, "r") as f:
-                    cached_resources = json.load(f)
-            except (IOError, OSError, json.JSONDecodeError):
-                pass
-        
+        cached_resources = _read_visa_cache()
+
         lan_resources = _discover_lan_resources()
         tried = set()
 
@@ -141,13 +163,9 @@ def get_instrument(resource_address: str, driver_type: str = "GENERIC") -> any:
             return None
 
         def update_cache(res):
-            try:
-                # Move successful resource to the front of the cache
-                new_cache = [res] + [r for r in cached_resources if r != res]
-                with open(cache_file, "w") as f:
-                    json.dump(new_cache[:10], f) # Keep top 10 for speed
-            except (IOError, OSError):
-                pass
+            # Move successful resource to the front of the cache
+            new_cache = [res] + [r for r in cached_resources if r != res]
+            _write_visa_cache(new_cache)
 
         def probe_resource(res):
             try:
@@ -289,17 +307,9 @@ def get_instrument(resource_address: str, driver_type: str = "GENERIC") -> any:
     
     # Update cache with successful manual connection to enable future AUTO discovery
     if resource_address != "AUTO":
-        try:
-            cache_file = ".visa_cache.json"
-            cached_resources = []
-            if os.path.exists(cache_file):
-                with open(cache_file, "r") as f:
-                    cached_resources = json.load(f)
-            new_cache = [resource_address] + [r for r in cached_resources if r != resource_address]
-            with open(cache_file, "w") as f:
-                json.dump(new_cache[:10], f)
-        except Exception:
-            pass
+        cached_resources = _read_visa_cache()
+        new_cache = [resource_address] + [r for r in cached_resources if r != resource_address]
+        _write_visa_cache(new_cache)
 
     return final_drv
 

--- a/tests/test_factory_cache.py
+++ b/tests/test_factory_cache.py
@@ -1,0 +1,51 @@
+import json
+
+from instrumation import factory
+
+
+def test_read_creates_cache_when_missing(tmp_path, monkeypatch):
+    """First read creates the cache file with an empty list and returns []."""
+    cache = tmp_path / ".visa_cache.json"
+    monkeypatch.setattr(factory, "CACHE_FILE", cache)
+
+    assert factory._read_visa_cache() == []
+    assert cache.exists()
+    assert json.loads(cache.read_text()) == []
+
+
+def test_write_then_read_roundtrip(tmp_path, monkeypatch):
+    """A written cache is read back, most-recent first."""
+    cache = tmp_path / ".visa_cache.json"
+    monkeypatch.setattr(factory, "CACHE_FILE", cache)
+
+    factory._write_visa_cache(["TCPIP0::1.2.3.4", "USB0::0x1"])
+    assert factory._read_visa_cache() == ["TCPIP0::1.2.3.4", "USB0::0x1"]
+
+
+def test_write_keeps_only_top_ten(tmp_path, monkeypatch):
+    """Only the first 10 resources are persisted."""
+    cache = tmp_path / ".visa_cache.json"
+    monkeypatch.setattr(factory, "CACHE_FILE", cache)
+
+    factory._write_visa_cache([f"RES{i}" for i in range(20)])
+    assert factory._read_visa_cache() == [f"RES{i}" for i in range(10)]
+
+
+def test_read_recovers_from_corrupt_cache(tmp_path, monkeypatch):
+    """A corrupt cache degrades to an empty list instead of raising."""
+    cache = tmp_path / ".visa_cache.json"
+    cache.write_text("{ not valid json")
+    monkeypatch.setattr(factory, "CACHE_FILE", cache)
+
+    assert factory._read_visa_cache() == []
+
+
+def test_read_after_external_delete(tmp_path, monkeypatch):
+    """Deleting the file mid-run does not raise; it is recreated empty."""
+    cache = tmp_path / ".visa_cache.json"
+    monkeypatch.setattr(factory, "CACHE_FILE", cache)
+
+    factory._write_visa_cache(["USB0::0x1"])
+    cache.unlink()
+    assert factory._read_visa_cache() == []
+    assert cache.exists()


### PR DESCRIPTION
## What & why

Fixes #122.

On a first run `.visa_cache.json` did not exist, so the AUTO-discovery path (guarded by `os.path.exists`) always skipped the cache and fell through to a full, slow VISA scan. The file was only ever created *after* a successful probe wrote to it. The read/write logic was also duplicated verbatim between the AUTO path and the manual-connection path.

## Changes

- Add `_read_visa_cache()` / `_write_visa_cache()` helpers backed by a module-level `pathlib.Path` (`CACHE_FILE`, overridable via the `INSTRUMATION_CACHE` env var).
- The reader **creates the cache with an empty list when missing**, so the first run seeds it and subsequent runs hit the cache.
- Both the AUTO-discovery and manual-connection cache blocks now route through the shared helpers (no duplicated `open()`/`json` logic).
- Helpers are best-effort: a missing, corrupt, or unwritable cache degrades to `[]` and never raises.

## Acceptance criteria

- [x] `.visa_cache.json` is created on the first AUTO connection attempt
- [x] Subsequent reads use the cache
- [x] Cache is still updated after successful connections
- [x] No error if the file is deleted while running (recreated empty)

## Tests

New `tests/test_factory_cache.py` (5 tests): create-when-missing, write/read roundtrip, top-10 truncation, corrupt-cache recovery, and recovery after an external delete. Full suite: **347 passed** (2 unrelated async *timing* tests are flaky under load and pass in isolation).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)