### PR TITLE
fix(drivers): route _unsupported_feature through logging instead of print

### DIFF
--- a/src/instrumation/drivers/base.py
+++ b/src/instrumation/drivers/base.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import List, Union, Dict, Any, Optional
 import asyncio
+import logging
+
 from ..results import MeasurementResult
 from ..exceptions import OverloadError, ConfigurationError
+
+logger = logging.getLogger(__name__)
 
 class InstrumentDriver(ABC):
     """Abstract Base Class for all instrument drivers following the 'Abstract Hardware' spec."""
@@ -127,7 +131,10 @@ class InstrumentDriver(ABC):
         return f"{dbm:.2f} DBM"
 
     def _unsupported_feature(self, feature_name: str) -> None:
-        print(f"Warning: Feature '{feature_name}' is not supported by {self.identity.get('model', 'Instrument')}")
+        model = self.identity.get("model") or "Instrument"
+        logger.warning(
+            "Feature '%s' is not supported by %s", feature_name, model
+        )
 
     def _validate_frequency(self, hz: float) -> None:
         if hz < self.min_frequency or hz > self.max_frequency:

--- a/tests/test_unsupported_feature.py
+++ b/tests/test_unsupported_feature.py
@@ -1,0 +1,88 @@
+"""Regression tests for issue #152: _unsupported_feature must log, not print.
+
+The method previously used ``print()``, which bypassed logging configuration
+entirely -- warnings were invisible to applications capturing log records and
+could not be filtered or formatted like every other library diagnostic.
+"""
+import logging
+
+import pytest
+
+from instrumation.drivers.base import InstrumentDriver
+from instrumation.results import MeasurementResult
+
+
+class _UnsupportedFeatureProbe(InstrumentDriver):
+    """Minimal concrete driver that inherits the base-class defaults."""
+
+    def connect(self) -> None: ...
+    def disconnect(self) -> None: ...
+    def write(self, command: str) -> None: ...
+    def query(self, command: str) -> str:
+        return ""
+
+    def get_id(self) -> str:
+        return "PROBE"
+
+    def preset(self, automation_optimized: bool = True) -> None: ...
+    def clear_status(self) -> None: ...
+    def sync_config(self) -> None: ...
+    def wait_ready(self, timeout: float = 30.0) -> None: ...
+    def shutdown_safety(self) -> None: ...
+    def check_errors(self) -> None: ...
+
+    def measure_frequency(self) -> MeasurementResult:
+        return MeasurementResult(0.0, "Hz")
+
+    def measure_duty_cycle(self) -> MeasurementResult:
+        return MeasurementResult(0.0, "%")
+
+    def measure_v_peak_to_peak(self) -> MeasurementResult:
+        return MeasurementResult(0.0, "V")
+
+
+@pytest.fixture
+def probe() -> InstrumentDriver:
+    return _UnsupportedFeatureProbe("GPIB::1::INSTR")
+
+
+def test_unsupported_feature_emits_logging_record(probe, caplog):
+    """save_state() on the base class must produce a WARNING log record."""
+    with caplog.at_level(logging.WARNING, logger="instrumation.drivers.base"):
+        probe.save_state(3)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelno == logging.WARNING
+    assert record.name == "instrumation.drivers.base"
+    assert "'save_state'" in record.getMessage()
+
+
+def test_unsupported_feature_does_not_write_to_stdout(probe, capsys):
+    """No warning text may leak to stdout anymore (#152)."""
+    with capsys.disabled():
+        pass
+    probe.save_state(3)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "not supported" not in captured.err
+
+
+def test_unsupported_feature_falls_back_to_generic_name(probe, caplog):
+    """An empty model string falls back to 'Instrument' (old code printed '')."""
+    probe.identity["model"] = ""
+    with caplog.at_level(logging.WARNING, logger="instrumation.drivers.base"):
+        probe.load_state(1)
+
+    assert len(caplog.records) == 1
+    assert "is not supported by Instrument" in caplog.records[0].getMessage()
+
+
+def test_unsupported_feature_includes_real_model_name(probe, caplog):
+    """A populated identity dict surfaces the actual model name."""
+    probe.identity["model"] = "MS2720T"
+    with caplog.at_level(logging.WARNING, logger="instrumation.drivers.base"):
+        probe.save_state(2)
+
+    assert len(caplog.records) == 1
+    assert "is not supported by MS2720T" in caplog.records[0].getMessage()


### PR DESCRIPTION
## Summary

Fixes the core defect in #152 (the logging-vs-print part of it):

- `InstrumentDriver._unsupported_feature()` emitted warnings via `print()`, bypassing logging configuration entirely. Applications capturing log records never saw these warnings, and they could not be filtered or formatted like every other library diagnostic.
- Added a module-level `logger` in `drivers/base.py`, matching the convention already used by `factory.py`, `generic.py`, `prologix.py`, and `registry.py`.
- Switched to `logger.warning()` with lazy `%`-formatting so the message is not built when WARNING is filtered out.
- Bonus fix found during testing: `identity.get('model', 'Instrument')` returned an empty string when the key existed with value `""` (the default only fires on a *missing* key). Now any falsy model falls back to `'Instrument'`.

All 38 call sites across 7 driver files route through this single method, so no per-driver changes were needed.

## Isolated testbench reproduction

Ran before and after the fix against the real code path (`MinimalProbe -> InstrumentDriver.save_state -> _unsupported_feature`), capturing stdout and log records separately:

**Pre-fix** (`bug_present: true`):
```
warnings_on_stdout:
  - "Warning: Feature 'save_state' is not supported by "
logging_records: []
```

**Post-fix** (`fixed: true`):
```
warnings_on_stdout: []
logging_records:
  - "Feature 'save_state' is not supported by Instrument"
```

## Test Plan

- [x] Baseline suite before changes: 454 passed
- [x] New regression tests `tests/test_unsupported_feature.py`: 4 passed
- [x] Full suite after changes: **458 passed** (no regressions)
- [x] `ruff check` clean on both touched files
- [x] Isolated testbench exercises the actual production method, not a mock

Ref #152