### PR TITLE
fix(station): make connect() idempotent to avoid double-connect

### DIFF
--- a/src/instrumation/station.py
+++ b/src/instrumation/station.py
@@ -88,8 +88,18 @@ class Station:
         logger.debug(f"Instrument '{name}' added to station.")
 
     def connect(self):
-        """Connects all initialized instruments."""
+        """Connects all initialized instruments.
+
+        ``get_instrument`` already connects each driver before it is stored by
+        :meth:`_add_instrument`, so instruments whose ``connected`` flag is
+        already set are skipped to avoid double-connecting (re-opening the VISA
+        resource and re-running sync/discovery). This keeps the operation
+        idempotent and safe for drivers whose ``connect()`` is not idempotent.
+        """
         for name, inst in self.instruments.items():
+            if inst.connected:
+                logger.debug(f"Instrument '{name}' already connected, skipping.")
+                continue
             try:
                 inst.connect()
                 logger.info(f"Connected to {name} at {inst.resource}")

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -316,6 +316,8 @@ def test_station_double_connect():
 
             with patch('instrumation.station.get_instrument') as mock_get:
                 mock_inst = MagicMock()
+                # get_instrument() connects the driver before Station stores it
+                mock_inst.connected = True
                 mock_get.return_value = mock_inst
 
                 station = Station("dummy.toml")
@@ -323,11 +325,12 @@ def test_station_double_connect():
                 # Connect once
                 station.connect()
 
-                # Connect again (double connect)
+                # Connect again (would be a double connect)
                 station.connect()
 
-                # Should not crash, and connect should be called twice
-                assert mock_inst.connect.call_count == 2
+                # Should not crash, and connect must NOT be called a second time
+                # (issue #156: drivers are already connected by get_instrument)
+                assert mock_inst.connect.call_count == 0
 
 
 # ── 11. SimulatedOscilloscope screenshot type ─────────────────────

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -86,6 +86,7 @@ class TestStation(unittest.TestCase):
         }
         mock_inst = MagicMock()
         mock_inst.resource = "ADDR"
+        mock_inst.connected = False  # freshly added instrument not yet connected
         mock_get_inst.return_value = mock_inst
         
         self.station.load()
@@ -93,6 +94,71 @@ class TestStation(unittest.TestCase):
         with self.assertLogs('instrumation.station', level='INFO') as cm:
             self.station.connect()
             self.assertTrue(any("Connected to sa at ADDR" in output for output in cm.output))
+
+    @patch('os.path.exists', return_value=True)
+    @patch('toml.load')
+    @patch('instrumation.station.get_instrument')
+    def test_connect_skips_already_connected_instrument(self, mock_get_inst, mock_toml_load, mock_exists):
+        """Regression test for #156: connect() must not double-connect.
+
+        get_instrument() already connects drivers before they are stored, so a
+        driver whose ``connected`` flag is already True must not have connect()
+        called again through the Station flow.
+        """
+        mock_toml_load.return_value = {
+            "instruments": {
+                "sa_already": {"driver": "SA", "address": "ADDR1"},
+                "sa_fresh": {"driver": "SA", "address": "ADDR2"},
+            }
+        }
+        already_connected = MagicMock()
+        already_connected.resource = "ADDR1"
+        already_connected.connected = True
+
+        fresh = MagicMock()
+        fresh.resource = "ADDR2"
+        fresh.connected = False
+
+        mock_get_inst.side_effect = [already_connected, fresh]
+
+        self.station.load()
+
+        self.station.connect()
+
+        # The already-connected instrument must NOT be re-connected.
+        already_connected.connect.assert_not_called()
+        # Only the fresh instrument gets connected.
+        fresh.connect.assert_called_once()
+
+    @patch('os.path.exists', return_value=True)
+    @patch('toml.load')
+    @patch('instrumation.station.get_instrument')
+    def test_connect_calls_connect_exactly_once_per_instrument(self, mock_get_inst, mock_toml_load, mock_exists):
+        """Acceptance criterion for #156: connect() is called exactly once.
+
+        Even when Station.connect() is invoked after load (where the driver is
+        already connected), calling connect() again must not re-open the VISA
+        resource. Repeated Station.connect() calls remain no-ops for connected
+        instruments.
+        """
+        mock_toml_load.return_value = {
+            "instruments": {"dmm": {"driver": "DMM", "address": "GPIB::1::INSTR"}}
+        }
+        # Simulate the real flow: get_instrument() connects the driver so its
+        # connected flag is already True when the Station stores it.
+        mock_inst = MagicMock()
+        mock_inst.resource = "GPIB::1::INSTR"
+        mock_inst.connected = True
+        mock_get_inst.return_value = mock_inst
+
+        self.station.load()
+
+        # connect() once
+        self.station.connect()
+        # connect() again -- still should not re-connect
+        self.station.connect()
+
+        mock_inst.connect.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`get_instrument()` already connects each driver before `Station._add_instrument` stores it. `Station.connect()` was then calling `inst.connect()` again on every instrument, which re-opens the VISA resource and re-runs `sync_config`/`_discover_identity`/`_discover_options` — wasteful, and an order-of-operations bug for drivers whose `connect()` is not idempotent.

`Station.connect()` now skips instruments whose `connected` flag is already set, making repeated `connect()` calls safe no-ops.

## Changes
- `src/instrumation/station.py` — skip already-connected instruments in `Station.connect()`
- `tests/test_station.py` — add regression tests asserting `connect()` is called at most once through the Station flow
- `tests/test_adversarial.py` — update `test_station_double_connect` (previously locked in the buggy double-call) to assert the new protected behaviour

## Test Plan
- `pytest tests/` → **456 passed**
- Isolated testbench (`TrackingSimDMM` with real `connected`/connect-count state): `Station.connect()` called twice leaves every instrument's `connect()` count at exactly 1 (no re-connect)

## Related
Fixes #156