### PR TITLE
fix(ci): Python 3.9 compat + implement ReplayDriver.query_binary_values

### DIFF
--- a/src/instrumation/config.py
+++ b/src/instrumation/config.py
@@ -5,6 +5,8 @@ station. Values are resolved with this precedence (highest wins):
 environment variables > config file > built-in defaults.
 """
 
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/src/instrumation/drivers/replay.py
+++ b/src/instrumation/drivers/replay.py
@@ -101,6 +101,11 @@ class ReplayDriver(SignalGenerator, SpectrumAnalyzer, NetworkAnalyzer, Oscillosc
         self.check_errors()
         return resp
 
+    def query_binary_values(self, command: str, datatype: str = 'f', is_big_endian: bool = False) -> List[float]:
+        resp = self.query(command)
+        self.check_errors()
+        return [float(v) for v in resp.split(",") if v.strip()]
+
     def get_id(self) -> str: return self.query("*IDN?")
     def preset(self, automation_optimized: bool = True) -> None: pass
     def clear_status(self) -> None: pass


### PR DESCRIPTION
## Summary
Fixes the two CI failures currently red on `main`.

1. **Python 3.9 test collection (TypeError)** — `config.py:44` uses PEP 604 union syntax (`-> Path | None`), which is evaluated at runtime on 3.9 and raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. CI matrix runs 3.9–3.13; the 3.9 job failed at collection and fail-fast cancelled the rest. Fix: `from __future__ import annotations` (lazy annotations — 3.9-safe, no behavior change).

2. **ReplayDriver un-instantiable (all versions)** — commit e2bf7cd marked `safe_send`/`query_ascii`/`query_binary_values` abstract in `base.py` and claimed "all concrete drivers implement them… ReplayDriver" but `replay.py` never got `query_binary_values`. Any `ReplayDriver(...)` instantiation raises `TypeError: Can't instantiate abstract class ReplayDriver with abstract method query_binary_values` — affecting the golden-master tests on every Python version. Hidden only because the 3.9 collection error cancelled the rest of the matrix. Fix: implement it replay-style, mirroring `query_ascii` (replay response + check_errors) and parsing comma-separated floats.

## Testbench (exact CI recipe, local)
- Python 3.9.13 + Python 3.11: 492/492 passed on both
- `ruff check .`: All checks passed
- Baseline before fix (3.9): reproduced the exact CI TypeError + 3 abstract-class collection failures

## Files
- `src/instrumation/config.py` (+2)
- `src/instrumation/drivers/replay.py` (+5)