### PR TITLE
docs: document GENERIC as a registered, discoverable registry key

### DIFF
--- a/docs/supported_instruments.md
+++ b/docs/supported_instruments.md
@@ -236,6 +236,22 @@ the same SCPI command set.
 
 ---
 
+## GENERIC (Universal Fallback)
+
+| Driver | Purpose | Auto-Detect IDN Keywords |
+|:---|:---|:---|
+| `GenericDriver` | Catch-all driver for unidentified instruments; accepts any model | none (explicit `"GENERIC"` request or unrecognized `*IDN?`) |
+
+`"GENERIC"` is a first-class, always-registered key in
+`DriverRegistry` — `get_drivers_by_type("GENERIC")` always returns
+`GenericDriver` (real mode) and `SimulatedGeneric` (SIM mode). It is used
+when `connect_instrument()` cannot identify an instrument, or when you
+explicitly pass `driver_type="GENERIC"` to `get_instrument()`. It exposes
+only generic SCPI passthrough (no typed measurement API), so it is a safe
+default, never a silent DMM/SA misread — see issue #148.
+
+---
+
 ## Summary
 
 | Category | Drivers | Validated Models |

--- a/src/instrumation/drivers/registry.py
+++ b/src/instrumation/drivers/registry.py
@@ -5,7 +5,19 @@ from .base import InstrumentDriver
 logger = logging.getLogger(__name__)
 
 class DriverRegistry:
-    """Registry to keep track of available instrument drivers."""
+    """Registry to keep track of available instrument drivers.
+
+    Drivers register themselves against a canonical instrument *type* key
+    (e.g. ``"DMM"``, ``"SA"``, ``"SCOPE"``). The full set of known keys is
+    defined in :data:`instrumation.factory.KNOWN_DRIVER_TYPES`.
+
+    ``"GENERIC"`` is a special, always-registered key: both
+    :class:`instrumation.drivers.generic.GenericDriver` and
+    :class:`instrumation.drivers.simulated.SimulatedGeneric` register
+    against it, so ``get_drivers_by_type("GENERIC")`` never returns an
+    empty list in a normal import. It is the universal fallback used when
+    an instrument cannot be identified (see issue #148).
+    """
     
     # Map of type -> list of driver classes
     _drivers: Dict[str, List[Type[InstrumentDriver]]] = {}


### PR DESCRIPTION
## Summary

Issue #148 asked that `"GENERIC"` be a *documented, discoverable* key in
`DriverRegistry`. The code half was resolved in #142 (`GenericDriver` and
`SimulatedGeneric` both register under `"GENERIC"`), but the
documentation half was never done: the registry docstring documented no
keys at all, and `docs/supported_instruments.md` never mentioned GENERIC.
A caller still had to read `factory.py` source to know GENERIC exists.

This PR closes that gap:

- **`src/instrumation/drivers/registry.py`** — the `DriverRegistry`
  docstring now documents the canonical type-key concept, points to
  `factory.KNOWN_DRIVER_TYPES`, and explicitly describes `"GENERIC"` as
  an always-registered fallback key with both registered classes.
- **`docs/supported_instruments.md`** — new **GENERIC (Universal
  Fallback)** section: the driver, when it is selected (explicit
  `driver_type="GENERIC"` or unrecognized `*IDN?`), and its deliberately
  untyped SCPI passthrough API (safe default, never a silent
  DMM/SA misread).

## Test Plan

- Ad-hoc verification harness: `get_drivers_by_type("GENERIC")` returns
  both `GenericDriver` and `SimulatedGeneric`; the new docs section and
  registry docstring text are present. PASS.
- Full suite: **518/518 tests pass** (no regressions).

Fixes #148