### PR TITLE
docs: fix ROADMAP.md staleness after v0.9.0 release (#188)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — v0.9.0
 
-**Target Release:** Q3 2026
+**Status:** Released 2026-09-05 (v0.9.0)
 
 ---
 
@@ -57,7 +57,7 @@ The dashboard (issues #118 launch, #119 React status cards, #120 CSV/JSON export
 
 ## Bug Fixes & Improvements
 
-All issue numbers below were reconciled against actual code + issue state (gh #158).
+All issue numbers below were reconciled against actual code + issue state (gh #158); re-verified after the v0.9.0 release (gh #188).
 
 | Issue | Description | Priority |
 | --- | --- | --- |
@@ -81,7 +81,7 @@ All issue numbers below were reconciled against actual code + issue state (gh #1
 | #145 | `factory.py`'s real-hardware IDN-routing and discovery paths were untested | ~~High~~ ✅ Fixed in v0.8.0 |
 | #146 | Real-mode `get_instrument()` silently falls back to `GENERIC` for unknown driver types like `SIM` | ✅ Fixed in v0.8.0 |
 | #147 | SIM-mode `driver_type="GENERIC"` silently mapped to `SimulatedMultimeter` | ✅ Fixed in v0.8.0 (`SimulatedGeneric` registered under `GENERIC`; `test_sim_generic_is_not_multimeter`) |
-| #148 | No `GENERIC` key documented/discoverable in `DriverRegistry` | Open (partially addressed — GENERIC is registered; discoverability docs pending) |
+| #148 | No `GENERIC` key documented/discoverable in `DriverRegistry` | ✅ Fixed in v0.9.0 (`docs/supported_instruments.md` "GENERIC (Universal Fallback)" section + `DriverRegistry` docstring; PR #186) |
 | #149 | Broad `except Exception` during IDN probing hides real connection errors | ✅ Fixed in v0.9.0 |
 | #150 | ASRL smart-probe sends vendor-specific TDK-Lambda commands to arbitrary serial devices | ✅ Fixed in v0.9.0 |
 | #151 | `probe_resource` ASRL port-number filter uses naive substring match | ✅ Fixed in v0.8.0 |
@@ -128,4 +128,4 @@ All issue numbers below were reconciled against actual code + issue state (gh #1
 | --- | --- |
 | 0.7.0 | Bug fixes + hardening (released) |
 | 0.8.0 | Generic driver fallback, PXA N9030A expansion, station/transport/logging hardening (released) |
-| 0.9.0 | Driver-factory + simulation fixes (#149–#168 batch), ROADMAP reconciliation (in progress) |
+| 0.9.0 | Driver-factory + simulation fixes (#149–#168 batch), ROADMAP reconciliation, v0.9.0 release (released 2026-09-05) |


### PR DESCRIPTION
## Summary

ROADMAP.md's bug table was reconciled in #158 (PR #184), but the v0.9.0 release and the GENERIC discoverability docs (PR #186) landed right after it, re-staling the document. This PR fixes the leftover rows (gh #188):

- **#148 row** — was `Open (partially addressed...)`. Now `✅ Fixed in v0.9.0` referencing the `docs/supported_instruments.md` "GENERIC (Universal Fallback)" section and the `DriverRegistry` docstring (registry.py) delivered in PR #186.
- **Version Planning** — v0.9.0 row marked `(in progress)` → `(released 2026-09-05)`.
- **Header** — `Target Release: Q3 2026` → `Status: Released 2026-09-05 (v0.9.0)`.
- Re-verification note added to the bug-table intro line.

## Verification

- Every claim in the changed rows checked against repo state (issue #148 closed 2026-09-05; GENERIC section present in `docs/supported_instruments.md`; `DriverRegistry` docstring documents GENERIC; `pyproject.toml` version 0.9.0; `release_notes.md` v0.9.0 section) — 9/9 ad-hoc checks pass.
- Full test suite: 517/517 pass on the branch (identical to baseline on main).

Fixes #188