### PR TITLE
feat(driver): Fluke 8845A/8846A Digital Multimeter

### DIFF
--- a/docs/supported_instruments.md
+++ b/docs/supported_instruments.md
@@ -217,6 +217,26 @@ on their published SCPI command references, not verified in-lab:
 > these models, prefer `"GENERIC"` passthrough or file an issue with
 > the failing command.
 
+### Fluke 8845A/8846A
+
+| Driver | Validated Model | SCPI Family | Auto-Detect IDN Keywords |
+|:---|:---|:---|:---|
+| `Fluke8846A` | 8846A | Fluke 884x Series | `FLUKE` + (`8845`, `8846`) |
+
+`Fluke8846A` is not validated against real hardware yet; it targets the
+`:MEAS:*?`/`:CONF:*` SCPI subset documented in the Fluke 8845A/8846A
+Programmer's Manual, mirroring `Keysight34461A`'s command shapes:
+
+| Model | Status |
+|:---|:---|
+| 8846A | Assumed compatible (6.5 digit, same measurement subsystem as 8845A) |
+| 8845A | Assumed compatible (5.5 digit, same command set as 8846A) |
+
+> [!WARNING]
+> Not yet verified against real hardware. If you hit an SCPI error,
+> prefer `"GENERIC"` passthrough or file an issue with the failing
+> command.
+
 ### Keithley 2000
 
 | Driver | Validated Model | SCPI Family | Auto-Detect IDN Keywords |
@@ -292,7 +312,7 @@ default, never a silent DMM/SA misread — see issue #148.
 | Spectrum Analyzers | 4 | MXA N9020A, PXA N9030A, DSA800, MS2830A |
 | Signal Generators | 5 | N5183B, AFG3022C, SMA100B, MG3700A, SMA100A |
 | Network Analyzers | 3 | N5232A, N9913A, MS2035B |
-| Multimeters | 2 | 34461A, 2000 |
+| Multimeters | 3 | 34461A, 2000, 8846A |
 | Power Supplies | 1 | Z+100-2 |
 | Electronic Loads | 1 | SDL1000X |
 | Frequency Counters | 1 | 53230A |

--- a/src/instrumation/drivers/__init__.py
+++ b/src/instrumation/drivers/__init__.py
@@ -16,6 +16,7 @@ from .simulated import (
 from .generic import GenericDriver
 from .keysight import Keysight53230A, KeysightPXA
 from .rigol import RigolDS1054Z
+from .fluke import Fluke8846A
 from .async_driver import (
     AsyncInstrumentDriver,
     AsyncMultimeter,
@@ -48,6 +49,7 @@ __all__ = [
     "Keysight53230A",
     "KeysightPXA",
     "RigolDS1054Z",
+    "Fluke8846A",
     "AsyncInstrumentDriver",
     "AsyncMultimeter",
     "AsyncPowerSupply",

--- a/src/instrumation/drivers/fluke.py
+++ b/src/instrumation/drivers/fluke.py
@@ -1,0 +1,78 @@
+from .base import Multimeter
+from .registry import register_driver
+from .real import RealDriver
+from ..results import MeasurementResult
+
+
+@register_driver("DMM")
+class Fluke8846A(RealDriver, Multimeter):
+    """Driver for Fluke 8845A/8846A 6.5-digit Digital Multimeters.
+
+    DCV, ACV, DCI, ACI, 2W/4W Resistance, Frequency, Period,
+    Temperature, Capacitance, and Diode test via SCPI (IEEE 488.2).
+    """
+
+    def preset(self, automation_optimized: bool = True) -> None:
+        self.write("*RST")
+        self.wait_ready()
+
+    def configure_voltage_dc(self) -> None:
+        self.safe_send(":CONF:VOLT:DC")
+
+    def configure_voltage_ac(self) -> None:
+        self.safe_send(":CONF:VOLT:AC")
+
+    def measure_voltage(self, ac: bool = False) -> MeasurementResult:
+        if ac:
+            val = self.query_ascii(":MEAS:VOLT:AC?")
+        else:
+            val = self.query_ascii(":MEAS:VOLT:DC?")
+        return MeasurementResult(float(val), "V")
+
+    def measure_resistance(self, four_wire: bool = False) -> MeasurementResult:
+        cmd = ":MEAS:FRES?" if four_wire else ":MEAS:RES?"
+        val = self.query_ascii(cmd)
+        return MeasurementResult(float(val), "Ohm")
+
+    def measure_current(self, ac: bool = False) -> MeasurementResult:
+        if ac:
+            val = self.query_ascii(":MEAS:CURR:AC?")
+        else:
+            val = self.query_ascii(":MEAS:CURR:DC?")
+        return MeasurementResult(float(val), "A")
+
+    def set_auto_range(self, state: bool) -> None:
+        val = "ON" if state else "OFF"
+        self.safe_send(f":VOLT:RANG:AUTO {val}")
+
+    def measure_frequency(self) -> MeasurementResult:
+        val = self.query_ascii(":MEAS:FREQ?")
+        return MeasurementResult(float(val), "Hz")
+
+    def measure_period(self) -> MeasurementResult:
+        val = self.query_ascii(":MEAS:PER?")
+        return MeasurementResult(float(val), "s")
+
+    def measure_temperature(self, probe_type: str = "TC", probe: str = "K") -> MeasurementResult:
+        val = self.query_ascii(f":MEAS:TEMP? {probe_type},{probe}")
+        return MeasurementResult(float(val), "C")
+
+    def measure_capacitance(self) -> MeasurementResult:
+        val = self.query_ascii(":MEAS:CAP?")
+        return MeasurementResult(float(val), "F")
+
+    def measure_diode(self) -> MeasurementResult:
+        val = self.query_ascii(":MEAS:DIOD?")
+        return MeasurementResult(float(val), "V")
+
+    def measure_duty_cycle(self) -> MeasurementResult:
+        self._unsupported_feature("Duty Cycle")
+        return MeasurementResult(0.0, "%")
+
+    def measure_v_peak_to_peak(self) -> MeasurementResult:
+        self._unsupported_feature("Vpp")
+        return MeasurementResult(0.0, "V")
+
+    def shutdown_safety(self) -> None:
+        self.set_auto_range(True)
+        self.sync_config()

--- a/src/instrumation/factory.py
+++ b/src/instrumation/factory.py
@@ -467,6 +467,10 @@ def get_instrument(resource_address: str, driver_type: str = "GENERIC", probe_as
     elif "PROLOGIX" in idn:
         from .drivers.prologix import PrologixDriver
         final_drv = PrologixDriver(resource_address)
+    elif "FLUKE" in idn:
+        if any(m in idn for m in ["8845", "8846"]):
+            from .drivers.fluke import Fluke8846A
+            final_drv = Fluke8846A(resource_address)
 
     if not final_drv:
         # No brand matched the IDN. If exactly one driver is registered for the

--- a/tests/test_factory_routing.py
+++ b/tests/test_factory_routing.py
@@ -51,6 +51,18 @@ class TestFactoryGenericFallback(unittest.TestCase):
             drv = get_instrument("TCPIP::10.0.0.7::INSTR", "DMM")
         self.assertEqual(drv.__class__.__name__, "Keithley2000")
 
+    def test_fluke_idn_routes_to_fluke8846a(self):
+        rm = _mock_rm("FLUKE,8846A,SN1,1.0")
+        with patch("instrumation.factory.get_rm", return_value=rm):
+            drv = get_instrument("TCPIP::10.0.0.8::INSTR", "DMM")
+        self.assertEqual(drv.__class__.__name__, "Fluke8846A")
+
+    def test_fluke_8845a_idn_routes_to_fluke8846a(self):
+        rm = _mock_rm("FLUKE,8845A,SN1,1.0")
+        with patch("instrumation.factory.get_rm", return_value=rm):
+            drv = get_instrument("TCPIP::10.0.0.9::INSTR", "DMM")
+        self.assertEqual(drv.__class__.__name__, "Fluke8846A")
+
 
 class TestFactoryGenericSimMode(unittest.TestCase):
     """Covers GH #142/#147: SIM-mode GENERIC must not secretly be a DMM."""

--- a/tests/test_fluke.py
+++ b/tests/test_fluke.py
@@ -1,0 +1,112 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from instrumation.drivers.fluke import Fluke8846A
+
+
+@pytest.fixture
+def mock_fluke():
+    with patch('pyvisa.ResourceManager'):
+        driver = Fluke8846A("TCPIP::1.2.3.6::INSTR")
+        driver.inst = MagicMock()
+        driver.inst.query.return_value = "1"
+        # This double doesn't model the SCPI error queue
+        driver.check_errors_enabled = False
+        yield driver
+
+
+def test_fluke_measure_dcv(mock_fluke):
+    mock_fluke.inst.query.return_value = "5.12345"
+    res = mock_fluke.measure_voltage()
+    assert res.value == 5.12345
+    assert res.unit == "V"
+    mock_fluke.inst.query.assert_any_call(":MEAS:VOLT:DC?")
+
+
+def test_fluke_measure_acv(mock_fluke):
+    mock_fluke.inst.query.return_value = "0.98765"
+    res = mock_fluke.measure_voltage(ac=True)
+    assert res.value == 0.98765
+    assert res.unit == "V"
+    mock_fluke.inst.query.assert_any_call(":MEAS:VOLT:AC?")
+
+
+def test_fluke_measure_resistance(mock_fluke):
+    mock_fluke.inst.query.return_value = "9998.5"
+    res = mock_fluke.measure_resistance()
+    assert res.value == 9998.5
+    assert res.unit == "Ohm"
+    mock_fluke.inst.query.assert_any_call(":MEAS:RES?")
+
+
+def test_fluke_measure_resistance_4wire(mock_fluke):
+    mock_fluke.inst.query.return_value = "9998.5"
+    res = mock_fluke.measure_resistance(four_wire=True)
+    assert res.value == 9998.5
+    assert res.unit == "Ohm"
+    mock_fluke.inst.query.assert_any_call(":MEAS:FRES?")
+
+
+def test_fluke_measure_dci(mock_fluke):
+    mock_fluke.inst.query.return_value = "0.05001"
+    res = mock_fluke.measure_current()
+    assert res.value == 0.05001
+    assert res.unit == "A"
+    mock_fluke.inst.query.assert_any_call(":MEAS:CURR:DC?")
+
+
+def test_fluke_measure_aci(mock_fluke):
+    mock_fluke.inst.query.return_value = "0.04001"
+    res = mock_fluke.measure_current(ac=True)
+    assert res.value == 0.04001
+    assert res.unit == "A"
+    mock_fluke.inst.query.assert_any_call(":MEAS:CURR:AC?")
+
+
+def test_fluke_measure_frequency(mock_fluke):
+    mock_fluke.inst.query.return_value = "1000.0"
+    res = mock_fluke.measure_frequency()
+    assert res.value == 1000.0
+    assert res.unit == "Hz"
+
+
+def test_fluke_measure_period(mock_fluke):
+    mock_fluke.inst.query.return_value = "0.001"
+    res = mock_fluke.measure_period()
+    assert res.value == 0.001
+    assert res.unit == "s"
+
+
+def test_fluke_measure_temperature(mock_fluke):
+    mock_fluke.inst.query.return_value = "23.45"
+    res = mock_fluke.measure_temperature()
+    assert res.value == 23.45
+    assert res.unit == "C"
+
+
+def test_fluke_measure_capacitance(mock_fluke):
+    mock_fluke.inst.query.return_value = "1.0e-6"
+    res = mock_fluke.measure_capacitance()
+    assert res.value == 1.0e-6
+    assert res.unit == "F"
+
+
+def test_fluke_measure_diode(mock_fluke):
+    mock_fluke.inst.query.return_value = "0.6543"
+    res = mock_fluke.measure_diode()
+    assert res.value == 0.6543
+    assert res.unit == "V"
+
+
+def test_fluke_unsupported_features_return_zero(mock_fluke):
+    duty = mock_fluke.measure_duty_cycle()
+    assert duty.value == 0.0
+    assert duty.unit == "%"
+
+    vpp = mock_fluke.measure_v_peak_to_peak()
+    assert vpp.value == 0.0
+    assert vpp.unit == "V"
+
+
+def test_fluke_shutdown_safety_restores_autorange(mock_fluke):
+    mock_fluke.shutdown_safety()
+    mock_fluke.inst.write.assert_any_call(":VOLT:RANG:AUTO ON")


### PR DESCRIPTION
## Summary

- Adds `Fluke8846A` driver (`src/instrumation/drivers/fluke.py`), registered under the `DMM` type, implementing the `Multimeter` interface (DCV/ACV, DCI/ACI, 2W/4W resistance, frequency, period, temperature, capacitance, diode).
- Follows the existing `Keysight34461A`/`Keithley2000` pattern (`:MEAS:*?`/`:CONF:*` SCPI subset per the Fluke 8845A/8846A Programmer's Manual).
- Wires IDN auto-routing in `factory.py`: `FLUKE` + (`8845`|`8846`) → `Fluke8846A`.
- Documents the driver in `docs/supported_instruments.md`, flagged as not yet validated against real hardware (same treatment as other assumed-compatible entries).

## Testing

- New unit tests in `tests/test_fluke.py` (mocked VISA) covering all measurement methods, unsupported-feature fallbacks, and shutdown safety.
- New IDN-routing tests in `tests/test_factory_routing.py` for both 8845A and 8846A identity strings.
- Full suite: 532/532 pass (517 baseline + 15 new).
- `ruff check` clean on all changed/added files.

Fixes #170