### PR TITLE
fix(rs_scope): parse HMO CHAN<n>:STAT? ON/OFF boolean in get_channel_display

### DIFF
--- a/src/instrumation/drivers/rs_scope.py
+++ b/src/instrumation/drivers/rs_scope.py
@@ -72,7 +72,15 @@ class RohdeSchwarzHMOCompact(RealDriver, Oscilloscope):
 
     def get_channel_display(self, channel: int) -> bool:
         self._validate_channel(channel)
-        return self.query(f"CHAN{channel}:STAT?").strip() == "1"
+        resp = self.query(f"CHAN{channel}:STAT?").strip().upper()
+        # HMO reports boolean state as ON/OFF (SCPI); fall back to 1/0
+        # so drivers mocking/test-harness backends that return numeric
+        # booleans keep working.
+        if resp in ("ON", "1"):
+            return True
+        if resp in ("OFF", "0"):
+            return False
+        raise ValueError(f"Unrecognized CHAN{channel}:STAT? response: {resp!r}")
 
     def set_channel_scale(self, channel: int, scale: float) -> None:
         self._validate_channel(channel)

--- a/tests/test_rs_scope.py
+++ b/tests/test_rs_scope.py
@@ -35,6 +35,21 @@ def test_channel_display(mock_hmo):
     assert mock_hmo.get_channel_display(1) is True
 
 
+def test_channel_display_scpi_on_off_dialect(mock_hmo):
+    # HMO reports CHAN<n>:STAT? as ON/OFF (SCPI boolean), not 1/0.
+    # Regression: the getter previously only accepted "1" and therefore
+    # always returned False for a genuinely-enabled HMO channel.
+    mock_hmo.inst.query.return_value = "ON"
+    assert mock_hmo.get_channel_display(1) is True
+    mock_hmo.inst.query.return_value = "on"
+    assert mock_hmo.get_channel_display(1) is True
+    mock_hmo.inst.query.return_value = "OFF"
+    assert mock_hmo.get_channel_display(1) is False
+    with pytest.raises(ValueError):
+        mock_hmo.inst.query.return_value = "BOGUS"
+        mock_hmo.get_channel_display(1)
+
+
 def test_channel_display_invalid_channel_raises(mock_hmo):
     with pytest.raises(ValueError):
         mock_hmo.set_channel_display(5, True)


### PR DESCRIPTION
## Summary

The HMO Compact driver's `get_channel_display()` only accepted the numeric
SCPI boolean literal `"1"`, but the HMO reports channel-display state as
`ON`/`OFF`. Result: a genuinely-enabled channel was always reported as
`False`.

## Fix

- Normalize the `CHAN<n>:STAT?` response (case-insensitive) and accept both
  `ON`/`OFF` and `1`/`0` dialects.
- Raise `ValueError` on an unrecognized response instead of silently
  returning `False` — a wrong measurement is worse than a loud failure.
- Keep the numeric fallback so mock/test-harness backends keep working.

## Tests

- Added regression test `test_channel_display_scpi_on_off_dialect` covering
  `ON`/`on`/`OFF` and the unrecognized-response path.
- Full suite: **588 passed** (including existing rs_scope tests).